### PR TITLE
Add Chinese font support for plots

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y \
     # --- Browser automation ---
     chromium \
     fonts-liberation \
+    fonts-noto-cjk \
+    fonts-wqy-zenhei \
     fonts-noto-color-emoji \
     libgbm1 \
     libnss3 \

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -402,6 +402,7 @@ async function runQuery(
     'Write and execute Python scripts or bash commands to produce real results.',
     'Save output files to /workspace/group/ so users can access them.',
     'When you generate an image file (such as PNG, JPG, or GIF), call mcp__bioclaw__send_image to send it to the user instead of only mentioning the saved file path in text.',
+    "If you generate plots with Chinese labels via matplotlib, configure a Chinese-capable font first (try: 'Noto Sans CJK SC' or 'WenQuanYi Zen Hei') and set axes.unicode_minus=False to avoid missing glyphs and minus-sign issues.",
     '',
   ].join('\n');
 


### PR DESCRIPTION
Install Chinese fonts in the agent image and guide matplotlib to use them to avoid missing glyphs in Chinese labels.

