### PR TITLE
Add more bioinformatics tools and restore second quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,13 +218,37 @@ In any WhatsApp group where BioClaw is connected, simply message:
 @Bioclaw <your request>
 ```
 
-For a no-think install helper flow, message OpenClaw with:
+## Second Quick Start
 
-```
-install https://github.com/Runchuan-BU/BioClaw
+Install from GitHub:
+
+```bash
+git clone https://github.com/Runchuan-BU/BioClaw.git
+cd BioClaw
+npm install
+docker build -t bioclaw-agent:latest container/
 ```
 
-OpenClaw will return one-click-style installation steps as a prompt-driven instruction flow (documentation-level convention, not a hardcoded command parser).
+If you want the bot name to be OpenClaw, set:
+
+```bash
+export ASSISTANT_NAME=OpenClaw
+```
+
+Just send the message to OpenClaw:
+
+```text
+@OpenClaw BLAST this sequence against nr: ATGCGATCGATCG...
+```
+
+### Group Management
+
+```bash
+npx tsx scripts/manage-groups.ts list         # Show registered groups
+npx tsx scripts/manage-groups.ts available    # Show all discovered groups
+npx tsx scripts/manage-groups.ts register     # Register a new group (interactive)
+npx tsx scripts/manage-groups.ts remove <jid> # Remove a group
+```
 
 See the [ExampleTask](ExampleTask/ExampleTask.md) document for 6 ready-to-use demo prompts with expected outputs.
 

--- a/README.md
+++ b/README.md
@@ -212,75 +212,19 @@ npm start
 
 ### Usage
 
-<<<<<<< HEAD
-```bash
-echo 'ANTHROPIC_API_KEY=your-key-here' > .env
-```
-
-Build the Docker container (includes all bio tools):
-
-```bash
-docker build -t bioclaw-agent:latest container/
-```
-
-Authenticate with WhatsApp (one-time):
-
-```bash
-npx tsx src/whatsapp-auth.ts
-```
-
-Register a WhatsApp group for the bot to respond in:
-
-```bash
-npx tsx scripts/manage-groups.ts register
-```
-
-Start BioClaw:
-
-```bash
-npx tsx src/index.ts
-```
-
-## Second Quick Start
-
-Install from GitHub:
-
-```bash
-git clone https://github.com/Runchuan-BU/BioClaw.git
-cd BioClaw
-npm install
-docker build -t bioclaw-agent:latest container/
-```
-
-If you want the bot name to be `OpenClaw`, set:
-
-```bash
-export ASSISTANT_NAME=OpenClaw
-```
-
-Just send the message to OpenClaw:
-
-```text
-@OpenClaw BLAST this sequence against nr: ATGCGATCGATCG...
-```
-
-### Group Management
-
-```bash
-npx tsx scripts/manage-groups.ts list        # Show registered groups
-npx tsx scripts/manage-groups.ts available    # Show all discovered groups
-npx tsx scripts/manage-groups.ts register     # Register a new group (interactive)
-npx tsx scripts/manage-groups.ts remove <jid> # Remove a group
-```
-
-## How It Works
-=======
 In any WhatsApp group where BioClaw is connected, simply message:
->>>>>>> origin/main
 
 ```
 @Bioclaw <your request>
 ```
+
+For a no-think install helper flow, message OpenClaw with:
+
+```
+install https://github.com/Runchuan-BU/BioClaw
+```
+
+OpenClaw will return one-click-style installation steps as a prompt-driven instruction flow (documentation-level convention, not a hardcoded command parser).
 
 See the [ExampleTask](ExampleTask/ExampleTask.md) document for 6 ready-to-use demo prompts with expected outputs.
 


### PR DESCRIPTION
Add pigz, tabix, SRA Toolkit, salmon, and kallisto to the default BioClaw container image, and update README usage docs with the restored Second Quick Start section for OpenClaw setup and group management commands.