### PR TITLE
fix: surface unstructured container stdout in logs

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -794,6 +794,11 @@ async function runBashTool(command: string, env: Record<string, string | undefin
       shell: '/bin/bash',
     });
 
+    // Log bash output to stderr so it appears in host logs
+    if (stdout.trim() || stderr.trim()) {
+      log(`[bash] ${[stdout.trim(), stderr.trim()].filter(Boolean).join('\n')}`);
+    }
+
     const combined = [stdout, stderr].filter(Boolean).join(stderr && stdout ? '\n' : '');
     return truncateOutput(combined || 'Command completed with no output.');
   } catch (err) {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -501,15 +501,6 @@ export async function runContainerAgent(
       fs.writeFileSync(logFile, logLines.join('\n'));
       logger.debug({ logFile, verbose: isVerbose }, 'Container log written');
 
-      // Warn on any stdout that falls outside the structured OUTPUT markers
-      // (e.g. Python print() calls). Silently dropping these hides script warnings.
-      const orphanStdout = stdout
-        .replace(/---BIOCLAW_OUTPUT_START---[\s\S]*?---BIOCLAW_OUTPUT_END---/g, '')
-        .trim();
-      if (orphanStdout && !isError) {
-        logger.warn({ group: group.name, logFile }, `Container unstructured output:\n${orphanStdout}`);
-      }
-
       if (code !== 0) {
         logger.error(
           {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -501,6 +501,15 @@ export async function runContainerAgent(
       fs.writeFileSync(logFile, logLines.join('\n'));
       logger.debug({ logFile, verbose: isVerbose }, 'Container log written');
 
+      // Warn on any stdout that falls outside the structured OUTPUT markers
+      // (e.g. Python print() calls). Silently dropping these hides script warnings.
+      const orphanStdout = stdout
+        .replace(/---BIOCLAW_OUTPUT_START---[\s\S]*?---BIOCLAW_OUTPUT_END---/g, '')
+        .trim();
+      if (orphanStdout && !isError) {
+        logger.warn({ group: group.name, logFile }, `Container unstructured output:\n${orphanStdout}`);
+      }
+
       if (code !== 0) {
         logger.error(
           {


### PR DESCRIPTION
When a container exits successfully (exit code 0), any stdout content outside the structured OUTPUT markers (e.g. Python print() warnings from scripts) was silently dropped. This made fallback behavior inscripts invisible unless LOG_LEVEL=debug was set.

Fix: after a successful container run, extract orphan stdout and log it at warn level so script warnings surface by default.