### PR TITLE
fix: satisfy IPC syncGroupMetadata promise type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -600,7 +600,10 @@ async function main(): Promise<void> {
     registerGroup,
     sendMessage: (jid, text) => sendToChannel(jid, text),
     sendImage: (jid, imagePath, caption) => sendImageToChannel(jid, imagePath, caption),
-    syncGroupMetadata: (force) => whatsapp?.syncGroupMetadata(force),
+    syncGroupMetadata: async (force) => {
+      if (!whatsapp) return;
+      await whatsapp.syncGroupMetadata(force);
+    },
     getAvailableGroups,
     writeGroupsSnapshot: (gf, im, ag, rj) => writeGroupsSnapshot(gf, im, ag, rj),
   });


### PR DESCRIPTION
## Summary

Fixes a TypeScript type error in `src/index.ts` that breaks the `Test` workflow on PRs.

The `startIpcWatcher` dependency contract requires `syncGroupMetadata: (force: boolean) => Promise<void>`, but the current callback uses optional chaining:

```ts
syncGroupMetadata: (force) => whatsapp?.syncGroupMetadata(force)
```

That expression returns `Promise<void> | undefined`, which causes `npx tsc --noEmit` to fail.

This PR changes it to an explicit async no-op when WhatsApp is unavailable, preserving the existing interface contract.

## Change

```ts
syncGroupMetadata: async (force) => {
  if (!whatsapp) return;
  await whatsapp.syncGroupMetadata(force);
},
```

## Testing

Confirmed from GitHub Actions logs that the failing job was caused by:

```text
src/index.ts(603,35): error TS2322: Type 'Promise<void> | undefined' is not assignable to type 'Promise<void>'.\n```\n\nThis fix is separated from the skill PR to comply with `CONTRIBUTING.md`.