### PR TITLE
Add homepage link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 <div align="center">
+<a href="https://ivegotmagicbean.github.io/BioClaw-Page/">
 <img src="bioclaw_logo.jpg" width="200">
-
+</a>
 
 # BioClaw
+
+<h3>🌐 <a href="https://ivegotmagicbean.github.io/BioClaw-Page/">Visit Project Homepage</a></h3>
 
 ### AI-Powered Bioinformatics Research Assistant on WhatsApp
 
@@ -10,6 +13,7 @@
 
 [![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/Runchuan-BU/BioClaw)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/Runchuan-BU/BioClaw/blob/main/LICENSE)
+[![Homepage](https://img.shields.io/badge/Homepage-BioClaw-blue.svg)](https://ivegotmagicbean.github.io/BioClaw-Page/)
 [![Paper](https://img.shields.io/badge/bioRxiv-STELLA-b31b1b.svg)](https://www.biorxiv.org/content/10.1101/2025.07.01.662467v2)
 [![arXiv](https://img.shields.io/badge/arXiv-2507.02004-b31b1b.svg)](https://arxiv.org/abs/2507.02004)
 


### PR DESCRIPTION
Added a badge for the project homepage to the README.

## Type of Change

- [ ] **Skill (dev)** - adds a meta skill in `.claude/skills/` (instructions for Claude Code)
- [ ] **Skill (runtime)** - adds/updates `container/skills/` for the chat agent
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
