### PR TITLE
Add query-genomic-intelligence skill

### DIFF
--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: query-genomic-intelligence
-description: Predict regulatory features, gene structure, and expression directly from DNA sequence using Genomic Intelligence's hosted transformer DNA models — no local GPU. Use when the user has a gene symbol, genomic region, or DNA/FASTA sequence and wants promoter, splice-site, enhancer, chromatin, expression (log TPM), or de-novo gene annotation predictions. Triggers on "genomic intelligence", "promoter prediction", "splice site", "enhancer activity", "chromatin state", "expression from sequence", "log TPM", "gene annotation", "DNA language model", "genomicintelligence.ai".
+description: Predict regulatory features, gene structure, and expression directly from DNA sequence using Genomic Intelligence's hosted transformer DNA models - no local GPU. Use when the user has a gene symbol, genomic region, or DNA/FASTA sequence and wants promoter, splice-site, enhancer, chromatin, expression (log TPM), or de-novo gene annotation predictions. Triggers on "genomic intelligence", "promoter prediction", "splice site", "enhancer activity", "chromatin state", "expression from sequence", "log TPM", "gene annotation", "DNA language model", "genomicintelligence.ai".
 ---
 
-# Genomic Intelligence — DNA Sequence Models
+# Genomic Intelligence - DNA Sequence Models
 
 Genomic Intelligence (GI) serves transformer DNA language models over six
 sequence-analysis tasks on managed GPUs. Give it a **gene symbol**, a **genomic
 region**, or a **DNA/FASTA sequence**; it returns structured predictions.
-Nothing runs locally — no model weights, no GPU. It is a thin client over a
+Nothing runs locally - no model weights, no GPU. It is a thin client over a
 hosted, versioned inference API.
 
-Docs: https://docs.genomicintelligence.ai · REST contract at
-https://api.genomicintelligence.ai/v1/openapi.json · hosted MCP server at
+Docs: https://docs.genomicintelligence.ai | REST contract at
+https://api.genomicintelligence.ai/v1/openapi.json | hosted MCP server at
 `https://mcp.genomicintelligence.ai/mcp`.
 
 > For research and development use, **not clinical or diagnostic decisions**.
@@ -21,21 +21,21 @@ https://api.genomicintelligence.ai/v1/openapi.json · hosted MCP server at
 
 Use GI when the user has DNA and wants a model prediction:
 
-- **promoter** — promoter regions in a genomic region (sliding window)
-- **splice** — donor/acceptor splice sites
-- **enhancer** — developmental & housekeeping enhancer activity (DeepSTARR)
-- **chromatin** — chromatin state across hundreds of tracks (DeepSEA)
-- **expression** — sequence-to-expression, log(TPM+1), with a cell-type context
-- **annotation** — de-novo gene/transcript annotation (async)
-- **composite** — find the genes in a region and predict each one's expression
+- **promoter** - promoter regions in a genomic region (sliding window)
+- **splice** - donor/acceptor splice sites
+- **enhancer** - developmental & housekeeping enhancer activity (DeepSTARR)
+- **chromatin** - chromatin state across hundreds of tracks (DeepSEA)
+- **expression** - sequence-to-expression, log(TPM+1), with a cell-type context
+- **annotation** - de-novo gene/transcript annotation (async)
+- **composite** - find the genes in a region and predict each one's expression
 
-Not for local alignment, variant calling, or file I/O — use a local tool
+Not for local alignment, variant calling, or file I/O - use a local tool
 (BioPython, bcftools) for those. GI is for **model inference from sequence**.
 
 ## Access and Authentication
 
 - The **hosted MCP server** (`https://mcp.genomicintelligence.ai/mcp`, Streamable
-  HTTP) works **keyless** against a capped public demo quota — prefer it on hosts
+  HTTP) works **keyless** against a capped public demo quota - prefer it on hosts
   that support MCP. An optional `gi_` bearer key raises the quota.
 - The **REST `/v1` API requires** a `GI_API_KEY` (a `gi_` bearer), sent as
   `Authorization: Bearer <key>`. Request one at contact@genomicintelligence.ai.
@@ -53,25 +53,26 @@ envelope.
 
 | Task | Mode | Length bound | Notes |
 |---|---|---|---|
-| `promoter` | sync | 1–500,000 bp | sliding-window promoter regions |
-| `splice` | sync | 1–500,000 bp | donor/acceptor sites (BigBird) |
-| `enhancer` | sync | 1–500,000 bp | dev + housekeeping (DeepSTARR, *Drosophila*) |
-| `chromatin` | sync | 1–500,000 bp | hundreds of tracks (DeepSEA) |
+| `promoter` | sync | 1-500,000 bp | sliding-window promoter regions |
+| `splice` | sync | 1-500,000 bp | donor/acceptor sites (BigBird) |
+| `enhancer` | sync | 1-500,000 bp | dev + housekeeping (DeepSTARR, *Drosophila*) |
+| `chromatin` | sync | 1-500,000 bp | hundreds of tracks (DeepSEA) |
 | `expression` | sync | **exactly 9,198 bp** | log(TPM+1); needs a cell-type `description` |
-| `annotation` | **async** | 1–500,000 bp | de-novo transcripts; submit + poll |
+| `annotation` | **async** | 1-500,000 bp | de-novo transcripts; submit + poll |
 
 Two hard rules the model enforces:
 
-- **`expression` needs exactly 9,198 bp**, centred on the TSS (2 × 4,599). Any
-  other length is rejected — build it from the canonical transcript's TSS, don't
+- **`expression` needs exactly 9,198 bp**, centred on the TSS (4,599 upstream +
+  TSS + 4,598 downstream). Any
+  other length is rejected - build it from the canonical transcript's TSS, don't
   truncate by hand.
-- **`expression` needs `options.description`** — a cell-type / assay string
+- **`expression` needs `options.description`** - a cell-type / assay string
   (e.g. `"K562 cells"`).
 
-**Omit `model` and the API uses the task's default** — that is the recommended
+**Omit `model` and the API uses the task's default** - that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults change
 and retired IDs fail hard, so never hardcode one. To pin a model, or to pick a
-non-human one (Drosophila, yeast, and Arabidopsis models exist for several tasks —
+non-human one (Drosophila, yeast, and Arabidopsis models exist for several tasks  - 
 match the species), discover IDs at call time with `GET /v1/tasks/{task}/models`
 (REST) or `list_models` (MCP). **Never invent a model ID.**
 
@@ -97,13 +98,13 @@ def gi_predict(task, sequence, sequence_name, model=None, options=None):
 out = gi_predict("promoter", seq, "TP53_region")
 print(out["data"]["summary"])
 
-# Expression — exactly 9,198 bp + a cell-type description:
+# Expression - exactly 9,198 bp + a cell-type description:
 out = gi_predict("expression", tss_window_9198bp, "HBB",
                  options={"description": "K562 cells"})
 print(out["data"]["prediction"]["expression_log_tpm"])
 ```
 
-Async (`annotation`) is submit-then-poll — send `Prefer: respond-async`, get a
+Async (`annotation`) is submit-then-poll - send `Prefer: respond-async`, get a
 `job_id`, then poll `GET /v1/tasks/jobs/{job_id}` until it returns `200` (a `202`
 means still running):
 
@@ -136,15 +137,21 @@ Acquire a **sequence handle** (`sequence_ref`), then predict against it, so larg
 sequences never enter the context:
 
 ```
-load_demo_sequence()                      # keyless smoke test -> handle
-fetch_ensembl_sequence(region="TP53")     # gene or region -> handle
+load_demo_sequence(name="promoter_tp53")  # keyless smoke test -> handle; name REQUIRED
+fetch_ensembl_sequence(gene="TP53")       # gene symbol or Ensembl ID -> handle
+fetch_region(region="chr11:5,225,000-5,235,000")   # coordinates -> handle
 fetch_gene_for_expression(gene="HBB")     # TSS-centred 9,198 bp handle
 predict_promoter(sequence_ref=<ref>)      # + predict_splice/_enhancer/_chromatin
 predict_expression(sequence_ref=<ref>, description="K562 cells")
-find_genes_and_predict_expression(region=..., description=...)   # composite
+find_genes(sequence_ref=<ref>)                                   # annotation task
+find_genes_and_predict_expression(sequence_ref=<ref>, description=...)  # composite
 ```
 
-`annotation` is async on MCP too: submit, then `get_job(job_id)` until terminal.
+Note the hosted server exposes 15 tools and has **no** `predict_annotation`: the
+annotation task is `find_genes`, which takes a handle rather than a region and
+runs async internally (`wait=True` by default returns the result; `wait=False`
+returns a `job_id` to poll with `get_job`). There is no `load_local_fasta` on the
+hosted server either; use `store_inline_sequence`.
 Reference context lives in the `gi://models`, `gi://docs/tasks`, and
 `gi://account` MCP resources.
 
@@ -153,13 +160,13 @@ Reference context lives in the `gi://models`, `gi://docs/tasks`, and
 | Method | Path | Purpose |
 |---|---|---|
 | POST | `/v1/tasks/{task}/predict` | Run a task (add `Prefer: respond-async` for annotation) |
-| GET | `/v1/tasks/jobs/{job_id}` | Poll an async job (202 running → 200 terminal) |
+| GET | `/v1/tasks/jobs/{job_id}` | Poll an async job (202 running -> 200 terminal) |
 | GET | `/v1/tasks/{task}/models` | List available model IDs for a task |
 
 ## Notes
 
 - Errors: `400` invalid (expression must be exactly 9,198 bp + `description`),
-  `401` missing/invalid key (REST), `413` too long (≤500,000 bp), `429` rate cap
+  `401` missing/invalid key (REST), `413` too long (<=500,000 bp), `429` rate cap
   (back off / ask GI to raise the tier), `5xx` retry.
 - GI is a hosted service; nothing here ships weights or runs local inference.
 

--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -26,7 +26,7 @@ Use GI when the user has DNA and wants a model prediction:
 - **enhancer** - developmental & housekeeping enhancer activity (DeepSTARR)
 - **chromatin** - chromatin state across hundreds of tracks (DeepSEA)
 - **expression** - sequence-to-expression, log(TPM+1), with a cell-type context
-- **annotation** - de-novo gene/transcript annotation (async)
+- **annotation** - de-novo gene/transcript annotation (async recommended)
 - **composite** - find the genes in a region and predict each one's expression
 
 Not for local alignment, variant calling, or file I/O - use a local tool
@@ -57,14 +57,16 @@ changes. Body `{sequence, sequence_name?, model?, options?}`, returning a
 `{data, meta}` envelope. `expression` is the strictest: alone among the six it
 requires `options` too - see the rules below.
 
-| Task | Mode | Accepted length | `context_window_bp` | Notes |
+| Task | Recommended mode | Accepted length | `context_window_bp` | Notes |
 |---|---|---|---|---|
 | `promoter` | sync | 300-500,000 bp | 2,000 bp | sliding-window promoter regions |
 | `splice` | sync | 100-500,000 bp | 15,000 bp | donor/acceptor sites (BigBird); strand-specific - feed transcript orientation |
 | `enhancer` | sync | 50-500,000 bp | 249 bp | dev + housekeeping (DeepSTARR, *Drosophila*) |
 | `chromatin` | sync | 200-500,000 bp | 1,000 bp | hundreds of tracks (DeepSEA) |
 | `expression` | sync | **9,198-500,000 bp** | n/a (`trained_window_bp` 9,198) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
-| `annotation` | **async** | 1,000-500,000 bp | n/a | de-novo transcripts; submit + poll |
+| `annotation` | async | 1,000-500,000 bp | n/a | de-novo transcripts; submit + poll |
+
+`Recommended mode` is guidance, not a constraint — every task accepts both. Omit `Prefer` for a synchronous `200`; send `Prefer: respond-async` for a `202` plus `GET /v1/tasks/jobs/{job_id}`. Only the composite workflow enforces a mode, rejecting sync above 50,000 bp with `413 sync_too_large`.
 
 **The minimum is admission control, not regime.** A request above the floor but
 shorter than the selected model's `bio_spec.context_window_bp` is *accepted and
@@ -163,7 +165,8 @@ print(out["meta"]["task_specific_counts"]["scored_window"])   # verify the right
 `Prefer: respond-async` is a declared header on **all six** predict operations
 and on the composite - a `202` carries the same `{data, meta}` envelope with
 `data = {job_id, status, links}` (job id also in `Content-Location` / `X-Job-Id`).
-Async is JSON-only. `annotation` is the task that needs it: send
+Async is JSON-only and available on every task; `annotation` is the one that
+usually needs it: send
 `Prefer: respond-async`, get a `job_id`, then poll `GET /v1/tasks/jobs/{job_id}`
 until it returns `200` (a `202` means still running):
 

--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -47,19 +47,44 @@ export GI_API_KEY="gi_yourkeyhere"     # optional for MCP; required for REST
 
 ## The Six Tasks
 
-Five of the six tasks share one shape: `POST /v1/tasks/{task}/predict` with body
-`{sequence, sequence_name, model?, options?}`, returning a `{data, meta}`
-envelope. `expression` uses the same URL but has its own published operation and
-a stricter body - see the rules below.
+Each task is **its own published operation** - `POST /v1/tasks/promoter/predict`,
+`/v1/tasks/splice/predict`, `/v1/tasks/enhancer/predict`,
+`/v1/tasks/chromatin/predict`, `/v1/tasks/annotation/predict`,
+`/v1/tasks/expression/predict` - with its own request schema, its own minimum
+length, and its own closed `options` object. There is no shared `PredictRequest`.
+The URLs are the same strings clients already POST to, so no URL construction
+changes. Body `{sequence, sequence_name?, model?, options?}`, returning a
+`{data, meta}` envelope. `expression` is the strictest: alone among the six it
+requires `options` too - see the rules below.
 
-| Task | Mode | Length bound | Notes |
-|---|---|---|---|
-| `promoter` | sync | 1-500,000 bp | sliding-window promoter regions |
-| `splice` | sync | 1-500,000 bp | donor/acceptor sites (BigBird) |
-| `enhancer` | sync | 1-500,000 bp | dev + housekeeping (DeepSTARR, *Drosophila*) |
-| `chromatin` | sync | 1-500,000 bp | hundreds of tracks (DeepSEA) |
-| `expression` | sync | **9,198-500,000 bp** | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
-| `annotation` | **async** | 1-500,000 bp | de-novo transcripts; submit + poll |
+| Task | Mode | Accepted length | Model context window | Notes |
+|---|---|---|---|---|
+| `promoter` | sync | 300-500,000 bp | 2,000 bp | sliding-window promoter regions |
+| `splice` | sync | 100-500,000 bp | 15,000 bp | donor/acceptor sites (BigBird); strand-specific - feed transcript orientation |
+| `enhancer` | sync | 50-500,000 bp | 249 bp | dev + housekeeping (DeepSTARR, *Drosophila*) |
+| `chromatin` | sync | 200-500,000 bp | 1,000 bp | hundreds of tracks (DeepSEA) |
+| `expression` | sync | **9,198-500,000 bp** | 9,198 bp (fixed) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
+| `annotation` | **async** | 1,000-500,000 bp | n/a | de-novo transcripts; submit + poll |
+
+**The minimum is admission control, not regime.** A request above the floor but
+shorter than the selected model's `bio_spec.context_window_bp` is *accepted and
+scored* - against a window padded out to the context window. Enhancer is the
+sharp case: the bound is 50 bp (DeepSTARR's gate) but the context window is
+249 bp, so 50-248 bp is scored mostly on padding. Compare your length against
+`context_window_bp` from `GET /v1/tasks/{task}/models` to know whether the model
+saw real sequence. Longer input is fine - the scanner steps a prediction window
+at a time and pads only the final partial window.
+
+Under the floor **and over the 500,000 bp cap** are both `422 validation_failed`
+at `loc ["body","sequence"]` - over-length is *not* a `413`. All lengths are
+measured after whitespace is stripped, so a line-wrapped FASTA body pastes
+verbatim (a `>` header line still fails the alphabet check).
+
+`options` is typed and **closed** (`additionalProperties: false`) per task - an
+unknown key is a hard `422` (`type: "extra_forbidden"`), never ignored: promoter
+`threshold`; splice `threshold`, `site_types`; enhancer none; chromatin
+`threshold`; annotation `batch_size`, `shift_coordinates`,
+`reverse_complement`; expression `description` (required, and the only key).
 
 Three hard rules the API enforces for `expression` (every violation is a `422`;
 nothing is padded, clamped, or truncated, and there is no opt-out flag):
@@ -84,6 +109,11 @@ nothing is padded, clamped, or truncated, and there is no opt-out flag):
 > `.tss_index`) in the response. Note also that `data.input.sequence_length` is
 > the **scored** length (always 9,198); the length you submitted is
 > `data.input.submitted_sequence_length` / `meta.sequence_length`.
+>
+> Both `tss_index` failures - "required unless exactly 9,198 bp" and the range
+> check - come from a whole-model validator, so they report at `loc: ["body"]`,
+> **never** `body.tss_index`. Match on `error.code == "validation_failed"`; never
+> branch on `loc`.
 
 **Omit `model` and the API uses the task's default** - that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults change
@@ -108,7 +138,10 @@ def gi_predict(task, sequence, sequence_name, model=None, options=None, tss_inde
     if options: body["options"] = options
     if tss_index is not None: body["tss_index"] = tss_index   # expression only
     r = requests.post(f"{BASE}/v1/tasks/{task}/predict", headers=HEADERS, json=body)
-    r.raise_for_status()          # 422 validation; 401 no/bad key; 413 too long; 429 rate limit
+    # 422 validation_failed - under the task floor OR over 500,000 bp, bad
+    #   tss_index, missing options.description, or ANY unknown body/options key
+    # 401 no/bad key | 404 unknown task | 413 body over 16 MiB | 429 rate limit
+    r.raise_for_status()
     return r.json()               # {"data": {...}, "meta": {...}}
 
 # Promoter:
@@ -127,9 +160,12 @@ out = gi_predict("expression", locus_seq, "HBB", options={"description": "K562 c
 print(out["meta"]["task_specific_counts"]["scored_window"])   # verify the right window
 ```
 
-Async (`annotation`) is submit-then-poll - send `Prefer: respond-async`, get a
-`job_id`, then poll `GET /v1/tasks/jobs/{job_id}` until it returns `200` (a `202`
-means still running):
+`Prefer: respond-async` is a declared header on **all six** predict operations
+and on the composite - a `202` carries the same `{data, meta}` envelope with
+`data = {job_id, status, links}` (job id also in `Content-Location` / `X-Job-Id`).
+Async is JSON-only. `annotation` is the task that needs it: send
+`Prefer: respond-async`, get a `job_id`, then poll `GET /v1/tasks/jobs/{job_id}`
+until it returns `200` (a `202` means still running):
 
 ```python
 import time
@@ -154,6 +190,9 @@ from the gene's canonical transcript (`expand=1`): 4,599 bp upstream + 4,598 bp
 downstream on the gene's strand - or fetch a wider locus and pass the TSS offset
 as `tss_index` and let the server cut it. Default species is **human, GRCh38**; use the
 Ensembl production name for others (`mus_musculus`, `drosophila_melanogaster`).
+Fetch at least the task floor (promoter 300, splice 100, enhancer 50, chromatin
+200, annotation 1,000 bp) - and ideally at least the model's `context_window_bp`,
+or the score reflects padding rather than sequence.
 
 ## Hosted MCP (keyless, preferred on MCP hosts)
 
@@ -183,20 +222,54 @@ Reference context lives in the `gi://models`, `gi://docs/tasks`, and
 
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/v1/tasks/{task}/predict` | Run a task (add `Prefer: respond-async` for annotation) |
-| GET | `/v1/tasks/jobs/{job_id}` | Poll an async job (202 running -> 200 terminal) |
-| GET | `/v1/tasks/{task}/models` | List available model IDs for a task |
+| POST | `/v1/tasks/<task>/predict` | Six literal paths, one per task (add `Prefer: respond-async` for annotation). An unrecognised task is `404 not_found`, not a 422 |
+| POST | `/v1/workflows/find-genes-and-predict-expression` | Composite (see below) |
+| GET | `/v1/tasks/jobs` · `/v1/tasks/jobs/{job_id}` | List / poll async jobs (202 running -> 200 terminal) |
+| GET | `/v1/tasks/{task}/models` | Model IDs + `bio_spec` for a task. Needs a key, and returns a **flat** `{task, default_model, models}` - not the `{data, meta}` envelope |
+
+`bio_spec` carries `request_max_bp` (the enforced cap, 500,000 everywhere),
+`context_window_bp` (the sliding window; null for annotation/expression) and
+`trained_window_bp` (9,198 for `g0-expression`). `max_seq_length_bp` is legacy and
+ambiguous - it is 9,198 for `g0-expression` (the trained window, not a cap), so
+prefer `request_max_bp`. There is no `strand_sensitive` flag.
 
 ## Notes
 
-- Errors: `422` validation (expression below 9,198 bp, missing/out-of-range
-  `tss_index`, or missing `options.description`), `401` missing/invalid key
-  (REST), `413` too long (<=500,000 bp), `429` rate cap
-  (back off / ask GI to raise the tier), `5xx` retry.
+- Errors: `422 validation_failed` is the catch-all - sequence under the task
+  floor **or over 500,000 bp**, expression below 9,198 bp, missing/out-of-range
+  `tss_index`, missing `options.description`, or any unknown body/`options` key.
+  `401`/`403` missing/invalid key (REST). `404 not_found` unknown task or job.
+  `413` means only `payload_too_large` (the 16 MiB raw-body cap) or
+  `sync_too_large` (the composite above 50,000 bp synchronous - retry async),
+  never an over-long sequence. `415 unsupported_format` for a bad `format` query
+  value - there is no silent fallback to JSON. `429` rate cap (honour
+  `Retry-After`; ask GI to raise the tier). `5xx` retry.
+- `error.code` is a closed 21-value enum; treat an unlisted value as a generic
+  failure, not a parse error. Branch on `code`, never on `details` or `loc`:
+  `details` currently arrives as a bare FastAPI error array even though the
+  schema declares an `{errors: [...]}` object, so read it defensively.
+  `error.request_id` mirrors the `X-Request-Id` header; every response carries
+  `RateLimit-*` headers.
+- Schema-version note: this describes `2026.08.19.4`. Production may still serve
+  `2026.08.18.1` until that build is promoted, where the six literal operations,
+  typed `options`, per-task floors, the published composite, the `Prefer`
+  parameter, the `code` enum and the new `bio_spec` fields are absent. URLs and
+  envelopes are unchanged either way - check `info.version` in
+  `/v1/openapi.json`.
 - GI is a hosted service; nothing here ships weights or runs local inference.
 
 ## Follow-up Suggestions
 
-- For "what genes are here and how are they expressed?", use the composite.
+- For "what genes are here and how are they expressed?", use the composite:
+  `POST /v1/workflows/find-genes-and-predict-expression` (REST) or
+  `find_genes_and_predict_expression` (MCP). `sequence` 1,000-500,000 bp and
+  `options` are required, and `options.description` (cell type / assay) is
+  required too - a missing or empty value is a `422`. It cuts a TSS-centred
+  9,198 bp window per discovered gene (padding with `N` at region edges rather
+  than dropping a gene) and returns a prediction each;
+  `meta.task_specific_counts` = `{genes_found, genes_predicted, genes_skipped}`,
+  per-gene causes in `data.expression_predictions[].skip_reason`. Above
+  **50,000 bp** a synchronous call is `413 sync_too_large` - retry the same body
+  with `Prefer: respond-async`.
 - To explore available models per task, call `list_models` / `GET .../models`
   before predicting.

--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -47,9 +47,10 @@ export GI_API_KEY="gi_yourkeyhere"     # optional for MCP; required for REST
 
 ## The Six Tasks
 
-All REST tasks share one shape: `POST /v1/tasks/{task}/predict` with body
+Five of the six tasks share one shape: `POST /v1/tasks/{task}/predict` with body
 `{sequence, sequence_name, model?, options?}`, returning a `{data, meta}`
-envelope.
+envelope. `expression` uses the same URL but has its own published operation and
+a stricter body - see the rules below.
 
 | Task | Mode | Length bound | Notes |
 |---|---|---|---|
@@ -57,17 +58,32 @@ envelope.
 | `splice` | sync | 1-500,000 bp | donor/acceptor sites (BigBird) |
 | `enhancer` | sync | 1-500,000 bp | dev + housekeeping (DeepSTARR, *Drosophila*) |
 | `chromatin` | sync | 1-500,000 bp | hundreds of tracks (DeepSEA) |
-| `expression` | sync | **exactly 9,198 bp** | log(TPM+1); needs a cell-type `description` |
+| `expression` | sync | **9,198-500,000 bp** | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
 | `annotation` | **async** | 1-500,000 bp | de-novo transcripts; submit + poll |
 
-Two hard rules the model enforces:
+Three hard rules the API enforces for `expression` (every violation is a `422`;
+nothing is padded, clamped, or truncated, and there is no opt-out flag):
 
-- **`expression` needs exactly 9,198 bp**, centred on the TSS (4,599 upstream +
-  TSS + 4,598 downstream). Any
-  other length is rejected - build it from the canonical transcript's TSS, don't
-  truncate by hand.
-- **`expression` needs `options.description`** - a cell-type / assay string
-  (e.g. `"K562 cells"`).
+- **The model always scores exactly one 9,198 bp TSS-centred window** -
+  `sequence[tss_index-4599 : tss_index+4599]`. The endpoint accepts
+  **9,198-500,000 bp**; below 9,198 bp is a hard `422`.
+- **`tss_index` is required unless the sequence is exactly 9,198 bp.** It is the
+  0-based TSS offset into the **whitespace-stripped** sequence, and must satisfy
+  `4599 <= tss_index <= len(sequence) - 4599`. At exactly 9,198 bp it defaults to
+  4,599 - the only legal value there. Hand over a whole locus (up to 500 kb) plus
+  a `tss_index` and the server cuts the window for you; it does **not** discover
+  the TSS itself, and it does **not** reverse-complement - submit gene-sense.
+- **`options.description`** - a cell-type / assay string (e.g. `"K562 cells"`) -
+  is required, and is the *only* key `expression` accepts inside `options`.
+  Unknown top-level body fields are also rejected.
+
+> Gotcha: the legal `tss_index` range is wide, so a *wrong but in-range* offset
+> (e.g. counted over the raw FASTA including newlines, or relative to a locus
+> start instead of the submitted slice) returns a confident `200` for the wrong
+> window. Always assert on `meta.task_specific_counts.scored_window` (and
+> `.tss_index`) in the response. Note also that `data.input.sequence_length` is
+> the **scored** length (always 9,198); the length you submitted is
+> `data.input.submitted_sequence_length` / `meta.sequence_length`.
 
 **Omit `model` and the API uses the task's default** - that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults change
@@ -86,22 +102,29 @@ import os, requests
 BASE = os.environ.get("GI_BASE_URL", "https://api.genomicintelligence.ai")
 HEADERS = {"Authorization": f"Bearer {os.environ['GI_API_KEY']}"}
 
-def gi_predict(task, sequence, sequence_name, model=None, options=None):
+def gi_predict(task, sequence, sequence_name, model=None, options=None, tss_index=None):
     body = {"sequence": sequence, "sequence_name": sequence_name}
     if model:   body["model"] = model
     if options: body["options"] = options
+    if tss_index is not None: body["tss_index"] = tss_index   # expression only
     r = requests.post(f"{BASE}/v1/tasks/{task}/predict", headers=HEADERS, json=body)
-    r.raise_for_status()          # 400 invalid; 401 no/bad key; 413 too long; 429 rate limit
+    r.raise_for_status()          # 422 validation; 401 no/bad key; 413 too long; 429 rate limit
     return r.json()               # {"data": {...}, "meta": {...}}
 
 # Promoter:
 out = gi_predict("promoter", seq, "TP53_region")
 print(out["data"]["summary"])
 
-# Expression - exactly 9,198 bp + a cell-type description:
+# Expression - a pre-cut 9,198 bp TSS-centred window (tss_index defaults to 4,599):
 out = gi_predict("expression", tss_window_9198bp, "HBB",
                  options={"description": "K562 cells"})
 print(out["data"]["prediction"]["expression_log_tpm"])
+
+# Expression - a whole locus, server cuts the window around the TSS you name.
+# tss_index is 0-based into the whitespace-stripped sequence.
+out = gi_predict("expression", locus_seq, "HBB", options={"description": "K562 cells"},
+                 tss_index=tss_offset_in_locus)
+print(out["meta"]["task_specific_counts"]["scored_window"])   # verify the right window
 ```
 
 Async (`annotation`) is submit-then-poll - send `Prefer: respond-async`, get a
@@ -126,9 +149,10 @@ transcripts = j.json()["data"]["transcripts"]
 
 You rarely start from a raw sequence. Fetch reference sequence from **Ensembl
 REST** (`rest.ensembl.org`, public, no key) for a gene symbol or region, then
-feed it to GI. For `expression`, build the **exactly 9,198 bp TSS-centred window**
+feed it to GI. For `expression`, either build the **9,198 bp TSS-centred window**
 from the gene's canonical transcript (`expand=1`): 4,599 bp upstream + 4,598 bp
-downstream on the gene's strand. Default species is **human, GRCh38**; use the
+downstream on the gene's strand - or fetch a wider locus and pass the TSS offset
+as `tss_index` and let the server cut it. Default species is **human, GRCh38**; use the
 Ensembl production name for others (`mus_musculus`, `drosophila_melanogaster`).
 
 ## Hosted MCP (keyless, preferred on MCP hosts)
@@ -165,8 +189,9 @@ Reference context lives in the `gi://models`, `gi://docs/tasks`, and
 
 ## Notes
 
-- Errors: `400` invalid (expression must be exactly 9,198 bp + `description`),
-  `401` missing/invalid key (REST), `413` too long (<=500,000 bp), `429` rate cap
+- Errors: `422` validation (expression below 9,198 bp, missing/out-of-range
+  `tss_index`, or missing `options.description`), `401` missing/invalid key
+  (REST), `413` too long (<=500,000 bp), `429` rate cap
   (back off / ask GI to raise the tier), `5xx` retry.
 - GI is a hosted service; nothing here ships weights or runs local inference.
 

--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -232,9 +232,9 @@ Reference context lives in the `gi://models`, `gi://docs/tasks`, and
 
 `bio_spec` carries `request_max_bp` (the enforced cap, 500,000 everywhere),
 `context_window_bp` (the sliding window; null for annotation/expression) and
-`trained_window_bp` (9,198 for `g0-expression`). `max_seq_length_bp` is legacy and
-ambiguous - it is 9,198 for `g0-expression` (the trained window, not a cap), so
-prefer `request_max_bp`. There is no `strand_sensitive` flag.
+`trained_window_bp` (9,198 for `g0-expression`). The legacy `max_seq_length_bp`
+was retired in gpu_service `2026.08.19.5` and no longer appears in `bio_spec`;
+`request_max_bp` is the cap. There is no `strand_sensitive` flag.
 
 ## Notes
 
@@ -249,16 +249,16 @@ prefer `request_max_bp`. There is no `strand_sensitive` flag.
   `Retry-After`; ask GI to raise the tier). `5xx` retry.
 - `error.code` is a closed 21-value enum; treat an unlisted value as a generic
   failure, not a parse error. Branch on `code`, never on `details` or `loc`:
-  `details` currently arrives as a bare FastAPI error array even though the
-  schema declares an `{errors: [...]}` object, so read it defensively.
-  `error.request_id` mirrors the `X-Request-Id` header; every response carries
+  `details` matches the declared schema - a validation failure carries
+  `{errors: [{loc, msg, type}, ...]}` - so read it defensively all the same.
+  `error.request_id` mirrors the `X-Request-Id` header and both are always
+  populated; success envelopes carry `meta.request_id`. Every response carries
   `RateLimit-*` headers.
-- Schema-version note: this describes `2026.08.19.4`. Production may still serve
-  `2026.08.18.1` until that build is promoted, where the six literal operations,
-  typed `options`, per-task floors, the published composite, the `Prefer`
-  parameter, the `code` enum and the new `bio_spec` fields are absent. URLs and
-  envelopes are unchanged either way - check `info.version` in
-  `/v1/openapi.json`.
+- Schema-version note: this describes gpu_service `2026.08.19.5`, live on
+  `api.genomicintelligence.ai` - the six literal operations, typed `options`,
+  per-task floors, the published composite, the `Prefer` parameter, the `code`
+  enum and the `bio_spec` fields are all present. Check `info.version` in
+  `/v1/openapi.json` if a detail here does not match.
 - GI is a hosted service; nothing here ships weights or runs local inference.
 
 ## Follow-up Suggestions

--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -121,6 +121,18 @@ nothing is padded, clamped, or truncated, and there is no opt-out flag):
 > **never** `body.tss_index`. Match on `error.code == "validation_failed"`; never
 > branch on `loc`.
 
+**Splice: submit gene-sense.** Strand-specific, and the wrong strand fails
+silently. Submit transcript orientation, reverse-complementing minus-strand
+genes. A reverse-complemented sequence does *not* return zeros or an empty
+result: it returns plausible sites at different positions, often still at high
+confidence, and the site count can hold or collapse depending on the locus.
+**Neither the score nor the count tells you the orientation was wrong**, so
+there is no post-hoc check - get the orientation right on input. A gene-symbol
+fetch follows the gene's own strand; a coordinate fetch does not, so a
+minus-strand gene pulled by coordinates arrives antisense unless you
+reverse-complement it yourself. `expression` never reverse-complements either;
+`annotation` is strand-insensitive.
+
 **Omit `model` and the API uses the task's default** - that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults change
 and retired IDs fail hard, so never hardcode one. To pin a model, or to pick a

--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: query-genomic-intelligence
+description: Predict regulatory features, gene structure, and expression directly from DNA sequence using Genomic Intelligence's hosted transformer DNA models — no local GPU. Use when the user has a gene symbol, genomic region, or DNA/FASTA sequence and wants promoter, splice-site, enhancer, chromatin, expression (log TPM), or de-novo gene annotation predictions. Triggers on "genomic intelligence", "promoter prediction", "splice site", "enhancer activity", "chromatin state", "expression from sequence", "log TPM", "gene annotation", "DNA language model", "genomicintelligence.ai".
+---
+
+# Genomic Intelligence — DNA Sequence Models
+
+Genomic Intelligence (GI) serves transformer DNA language models over six
+sequence-analysis tasks on managed GPUs. Give it a **gene symbol**, a **genomic
+region**, or a **DNA/FASTA sequence**; it returns structured predictions.
+Nothing runs locally — no model weights, no GPU. It is a thin client over a
+hosted, versioned inference API.
+
+Docs: https://docs.genomicintelligence.ai · REST contract at
+https://api.genomicintelligence.ai/v1/openapi.json · hosted MCP server at
+`https://mcp.genomicintelligence.ai/mcp`.
+
+> For research and development use, **not clinical or diagnostic decisions**.
+
+## When to Use
+
+Use GI when the user has DNA and wants a model prediction:
+
+- **promoter** — promoter regions in a genomic region (sliding window)
+- **splice** — donor/acceptor splice sites
+- **enhancer** — developmental & housekeeping enhancer activity (DeepSTARR)
+- **chromatin** — chromatin state across hundreds of tracks (DeepSEA)
+- **expression** — sequence-to-expression, log(TPM+1), with a cell-type context
+- **annotation** — de-novo gene/transcript annotation (async)
+- **composite** — find the genes in a region and predict each one's expression
+
+Not for local alignment, variant calling, or file I/O — use a local tool
+(BioPython, bcftools) for those. GI is for **model inference from sequence**.
+
+## Access and Authentication
+
+- The **hosted MCP server** (`https://mcp.genomicintelligence.ai/mcp`, Streamable
+  HTTP) works **keyless** against a capped public demo quota — prefer it on hosts
+  that support MCP. An optional `gi_` bearer key raises the quota.
+- The **REST `/v1` API requires** a `GI_API_KEY` (a `gi_` bearer), sent as
+  `Authorization: Bearer <key>`. Request one at contact@genomicintelligence.ai.
+- **Never hardcode the key.** Read it from the `GI_API_KEY` environment variable.
+
+```bash
+export GI_API_KEY="gi_yourkeyhere"     # optional for MCP; required for REST
+```
+
+## The Six Tasks
+
+All REST tasks share one shape: `POST /v1/tasks/{task}/predict` with body
+`{sequence, sequence_name, model?, options?}`, returning a `{data, meta}`
+envelope.
+
+| Task | Mode | Length bound | Notes |
+|---|---|---|---|
+| `promoter` | sync | 1–500,000 bp | sliding-window promoter regions |
+| `splice` | sync | 1–500,000 bp | donor/acceptor sites (BigBird) |
+| `enhancer` | sync | 1–500,000 bp | dev + housekeeping (DeepSTARR, *Drosophila*) |
+| `chromatin` | sync | 1–500,000 bp | hundreds of tracks (DeepSEA) |
+| `expression` | sync | **exactly 9,198 bp** | log(TPM+1); needs a cell-type `description` |
+| `annotation` | **async** | 1–500,000 bp | de-novo transcripts; submit + poll |
+
+Two hard rules the model enforces:
+
+- **`expression` needs exactly 9,198 bp**, centred on the TSS (2 × 4,599). Any
+  other length is rejected — build it from the canonical transcript's TSS, don't
+  truncate by hand.
+- **`expression` needs `options.description`** — a cell-type / assay string
+  (e.g. `"K562 cells"`).
+
+**Omit `model` and the API uses the task's default** — that is the recommended
+call. Default model IDs are intentionally **not** documented here: defaults change
+and retired IDs fail hard, so never hardcode one. To pin a model, or to pick a
+non-human one (Drosophila, yeast, and Arabidopsis models exist for several tasks —
+match the species), discover IDs at call time with `GET /v1/tasks/{task}/models`
+(REST) or `list_models` (MCP). **Never invent a model ID.**
+
+## How to Execute (REST)
+
+Sync tasks (promoter, splice, enhancer, chromatin, expression) are one call:
+
+```python
+import os, requests
+
+BASE = os.environ.get("GI_BASE_URL", "https://api.genomicintelligence.ai")
+HEADERS = {"Authorization": f"Bearer {os.environ['GI_API_KEY']}"}
+
+def gi_predict(task, sequence, sequence_name, model=None, options=None):
+    body = {"sequence": sequence, "sequence_name": sequence_name}
+    if model:   body["model"] = model
+    if options: body["options"] = options
+    r = requests.post(f"{BASE}/v1/tasks/{task}/predict", headers=HEADERS, json=body)
+    r.raise_for_status()          # 400 invalid; 401 no/bad key; 413 too long; 429 rate limit
+    return r.json()               # {"data": {...}, "meta": {...}}
+
+# Promoter:
+out = gi_predict("promoter", seq, "TP53_region")
+print(out["data"]["summary"])
+
+# Expression — exactly 9,198 bp + a cell-type description:
+out = gi_predict("expression", tss_window_9198bp, "HBB",
+                 options={"description": "K562 cells"})
+print(out["data"]["prediction"]["expression_log_tpm"])
+```
+
+Async (`annotation`) is submit-then-poll — send `Prefer: respond-async`, get a
+`job_id`, then poll `GET /v1/tasks/jobs/{job_id}` until it returns `200` (a `202`
+means still running):
+
+```python
+import time
+r = requests.post(f"{BASE}/v1/tasks/annotation/predict",
+                  headers={**HEADERS, "Prefer": "respond-async"},
+                  json={"sequence": seq, "sequence_name": "TP53"})
+r.raise_for_status()
+job_id = r.json()["data"]["job_id"]
+while True:
+    j = requests.get(f"{BASE}/v1/tasks/jobs/{job_id}", headers=HEADERS)
+    if j.status_code == 200: break
+    j.raise_for_status(); time.sleep(5)
+transcripts = j.json()["data"]["transcripts"]
+```
+
+## Sequence Acquisition
+
+You rarely start from a raw sequence. Fetch reference sequence from **Ensembl
+REST** (`rest.ensembl.org`, public, no key) for a gene symbol or region, then
+feed it to GI. For `expression`, build the **exactly 9,198 bp TSS-centred window**
+from the gene's canonical transcript (`expand=1`): 4,599 bp upstream + 4,598 bp
+downstream on the gene's strand. Default species is **human, GRCh38**; use the
+Ensembl production name for others (`mus_musculus`, `drosophila_melanogaster`).
+
+## Hosted MCP (keyless, preferred on MCP hosts)
+
+Acquire a **sequence handle** (`sequence_ref`), then predict against it, so large
+sequences never enter the context:
+
+```
+load_demo_sequence()                      # keyless smoke test -> handle
+fetch_ensembl_sequence(region="TP53")     # gene or region -> handle
+fetch_gene_for_expression(gene="HBB")     # TSS-centred 9,198 bp handle
+predict_promoter(sequence_ref=<ref>)      # + predict_splice/_enhancer/_chromatin
+predict_expression(sequence_ref=<ref>, description="K562 cells")
+find_genes_and_predict_expression(region=..., description=...)   # composite
+```
+
+`annotation` is async on MCP too: submit, then `get_job(job_id)` until terminal.
+Reference context lives in the `gi://models`, `gi://docs/tasks`, and
+`gi://account` MCP resources.
+
+## Key Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/v1/tasks/{task}/predict` | Run a task (add `Prefer: respond-async` for annotation) |
+| GET | `/v1/tasks/jobs/{job_id}` | Poll an async job (202 running → 200 terminal) |
+| GET | `/v1/tasks/{task}/models` | List available model IDs for a task |
+
+## Notes
+
+- Errors: `400` invalid (expression must be exactly 9,198 bp + `description`),
+  `401` missing/invalid key (REST), `413` too long (≤500,000 bp), `429` rate cap
+  (back off / ask GI to raise the tier), `5xx` retry.
+- GI is a hosted service; nothing here ships weights or runs local inference.
+
+## Follow-up Suggestions
+
+- For "what genes are here and how are they expressed?", use the composite.
+- To explore available models per task, call `list_models` / `GET .../models`
+  before predicting.

--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -57,13 +57,13 @@ changes. Body `{sequence, sequence_name?, model?, options?}`, returning a
 `{data, meta}` envelope. `expression` is the strictest: alone among the six it
 requires `options` too - see the rules below.
 
-| Task | Mode | Accepted length | Model context window | Notes |
+| Task | Mode | Accepted length | `context_window_bp` | Notes |
 |---|---|---|---|---|
 | `promoter` | sync | 300-500,000 bp | 2,000 bp | sliding-window promoter regions |
 | `splice` | sync | 100-500,000 bp | 15,000 bp | donor/acceptor sites (BigBird); strand-specific - feed transcript orientation |
 | `enhancer` | sync | 50-500,000 bp | 249 bp | dev + housekeeping (DeepSTARR, *Drosophila*) |
 | `chromatin` | sync | 200-500,000 bp | 1,000 bp | hundreds of tracks (DeepSEA) |
-| `expression` | sync | **9,198-500,000 bp** | 9,198 bp (fixed) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
+| `expression` | sync | **9,198-500,000 bp** | n/a (`trained_window_bp` 9,198) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
 | `annotation` | **async** | 1,000-500,000 bp | n/a | de-novo transcripts; submit + poll |
 
 **The minimum is admission control, not regime.** A request above the floor but

--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -15,7 +15,7 @@ Docs: https://docs.genomicintelligence.ai | REST contract at
 https://api.genomicintelligence.ai/v1/openapi.json | hosted MCP server at
 `https://mcp.genomicintelligence.ai/mcp`.
 
-> For research and development use, **not clinical or diagnostic decisions**.
+> Research and development use. Not for clinical or diagnostic decisions.
 
 ## When to Use
 
@@ -35,8 +35,9 @@ Not for local alignment, variant calling, or file I/O - use a local tool
 ## Access and Authentication
 
 - The **hosted MCP server** (`https://mcp.genomicintelligence.ai/mcp`, Streamable
-  HTTP) works **keyless** against a capped public demo quota - prefer it on hosts
-  that support MCP. An optional `gi_` bearer key raises the quota.
+  HTTP) works **keyless** against a rate- and concurrency-limited public demo
+  tier - prefer it on hosts that support MCP. An optional `gi_` bearer key
+  raises those limits.
 - The **REST `/v1` API requires** a `GI_API_KEY` (a `gi_` bearer), sent as
   `Authorization: Bearer <key>`. Request one at contact@genomicintelligence.ai.
 - **Never hardcode the key.** Read it from the `GI_API_KEY` environment variable.
@@ -66,12 +67,15 @@ requires `options` too - see the rules below.
 | `expression` | sync | **9,198-500,000 bp** | n/a (`trained_window_bp` 9,198) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
 | `annotation` | async | 1,000-500,000 bp | n/a | de-novo transcripts; submit + poll |
 
-`Recommended mode` is guidance, not a constraint — every task accepts both. Omit `Prefer` for a synchronous `200`; send `Prefer: respond-async` for a `202` plus `GET /v1/tasks/jobs/{job_id}`. Only the composite workflow enforces a mode, rejecting sync above 50,000 bp with `413 sync_too_large`.
+`Recommended mode` is latency guidance, not a constraint - every task accepts
+both. Omit `Prefer` for a synchronous `200`; send `Prefer: respond-async` for a
+`202` plus `GET /v1/tasks/jobs/{job_id}`. Only the composite workflow enforces a
+mode, rejecting sync above 50,000 bp with `413 sync_too_large`.
 
-**The minimum is admission control, not regime.** A request above the floor but
-shorter than the selected model's `bio_spec.context_window_bp` is *accepted and
-scored* - against a window padded out to the context window. Enhancer is the
-sharp case: the bound is 50 bp (DeepSTARR's gate) but the context window is
+**The minimum is admission control, not a scoring regime.** A request above
+the floor but shorter than the selected model's `bio_spec.context_window_bp`
+is *accepted and scored* - against a window padded out to the context window. Enhancer is the
+sharp case: the floor is 50 bp but the context window is
 249 bp, so 50-248 bp is scored mostly on padding. Compare your length against
 `context_window_bp` from `GET /v1/tasks/{task}/models` to know whether the model
 saw real sequence. Longer input is fine - the scanner steps a prediction window
@@ -104,7 +108,7 @@ nothing is padded, clamped, or truncated, and there is no opt-out flag):
   is required, and is the *only* key `expression` accepts inside `options`.
   Unknown top-level body fields are also rejected.
 
-> Gotcha: the legal `tss_index` range is wide, so a *wrong but in-range* offset
+> Trap: the legal `tss_index` range is wide, so a *wrong but in-range* offset
 > (e.g. counted over the raw FASTA including newlines, or relative to a locus
 > start instead of the submitted slice) returns a confident `200` for the wrong
 > window. Always assert on `meta.task_specific_counts.scored_window` (and
@@ -120,13 +124,14 @@ nothing is padded, clamped, or truncated, and there is no opt-out flag):
 **Omit `model` and the API uses the task's default** - that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults change
 and retired IDs fail hard, so never hardcode one. To pin a model, or to pick a
-non-human one (Drosophila, yeast, and Arabidopsis models exist for several tasks  - 
-match the species), discover IDs at call time with `GET /v1/tasks/{task}/models`
-(REST) or `list_models` (MCP). **Never invent a model ID.**
+non-human one (Drosophila, yeast, and Arabidopsis models exist for several
+tasks - match the species), discover IDs at call time with
+`GET /v1/tasks/{task}/models` (REST) or `list_models` (MCP). **Never invent a
+model ID.**
 
 ## How to Execute (REST)
 
-Sync tasks (promoter, splice, enhancer, chromatin, expression) are one call:
+Called synchronously - no `Prefer` header - a prediction is one request:
 
 ```python
 import os, requests
@@ -232,8 +237,8 @@ Reference context lives in the `gi://models`, `gi://docs/tasks`, and
 
 `bio_spec` carries `request_max_bp` (the enforced cap, 500,000 everywhere),
 `context_window_bp` (the sliding window; null for annotation/expression) and
-`trained_window_bp` (9,198 for `g0-expression`). The legacy `max_seq_length_bp`
-was retired in gpu_service `2026.08.19.5` and no longer appears in `bio_spec`;
+`trained_window_bp` (9,198 for the expression model). The legacy
+`max_seq_length_bp` has been withdrawn and no longer appears in `bio_spec`;
 `request_max_bp` is the cap. There is no `strand_sensitive` flag.
 
 ## Notes
@@ -254,11 +259,11 @@ was retired in gpu_service `2026.08.19.5` and no longer appears in `bio_spec`;
   `error.request_id` mirrors the `X-Request-Id` header and both are always
   populated; success envelopes carry `meta.request_id`. Every response carries
   `RateLimit-*` headers.
-- Schema-version note: this describes gpu_service `2026.08.19.5`, live on
-  `api.genomicintelligence.ai` - the six literal operations, typed `options`,
-  per-task floors, the published composite, the `Prefer` parameter, the `code`
-  enum and the `bio_spec` fields are all present. Check `info.version` in
-  `/v1/openapi.json` if a detail here does not match.
+- The API serves the six literal predict operations, typed `options`, per-task
+  floors, the published composite, the `Prefer` parameter, the `code` enum and
+  the `bio_spec` fields described here. The served schema at
+  https://api.genomicintelligence.ai/v1/openapi.json is the authority; check it
+  if a detail here does not match.
 - GI is a hosted service; nothing here ships weights or runs local inference.
 
 ## Follow-up Suggestions

--- a/container/skills/query-genomic-intelligence/SKILL.md
+++ b/container/skills/query-genomic-intelligence/SKILL.md
@@ -133,6 +133,13 @@ minus-strand gene pulled by coordinates arrives antisense unless you
 reverse-complement it yourself. `expression` never reverse-complements either;
 `annotation` is strand-insensitive.
 
+**A splice coordinate is a token span, not a junction.** Each site's
+`start`/`end` bounds one variable-width tokenizer token - 4-10 bp across the
+sequences measured so far - reported with a `token_index`. The exon/intron
+junction sits somewhere inside that span, so do not reduce the pair to a single
+base position, and do not intersect it against reference annotation as though it
+marked a boundary.
+
 **Omit `model` and the API uses the task's default** - that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults change
 and retired IDs fail hard, so never hardcode one. To pin a model, or to pick a


### PR DESCRIPTION
## Add `query-genomic-intelligence` skill

Adds a runtime skill wrapping Genomic Intelligence (GI), a set of hosted
transformer DNA language models that predict regulatory features, gene structure,
and expression directly from DNA sequence. No local GPU or model weights are
needed; the skill is a thin client over a hosted, versioned inference API.

Per `CONTRIBUTING.md`, new capabilities arrive as skills. This is a runtime skill
under `container/skills/`, modelled on `query-ensembl`: a single `SKILL.md` with
inline `requests`.

### What it does

Give it a gene symbol, a genomic region, or a DNA/FASTA sequence and it returns
structured predictions across six tasks, plus a composite:

- `promoter`: promoter regions
- `splice`: donor/acceptor splice sites
- `enhancer`: developmental and housekeeping activity
- `chromatin`: chromatin state across hundreds of tracks
- `expression`: sequence to expression, log(TPM+1)
- `annotation`: de-novo gene/transcript annotation
- composite: find the genes in a region and predict each one's expression

### How it connects

The REST `/v1` API needs a `GI_API_KEY` bearer and is called as
`POST /v1/tasks/{task}/predict`. The hosted MCP server at
`https://mcp.genomicintelligence.ai/mcp` works keyless against a public demo
quota, with the key optional.

The skill documents both paths, the Ensembl-based sequence acquisition (including
the exact 9,198 bp TSS-centred window the `expression` model requires), and the
async annotation poll.

### Scope

This is a skill-only change. It adds one file,
`container/skills/query-genomic-intelligence/SKILL.md`, and touches no source
files, so the skills-only PR check passes. Verified with
`git diff --name-only upstream/main...HEAD`, which lists that path alone.

No secrets are committed; the key is read from the `GI_API_KEY` environment
variable. The keyless MCP path was verified against the live endpoint: an
anonymous Streamable HTTP session with no `Authorization` header completes
`initialize` and returns a real `predict_promoter` result.

### Notes

For research and development use, not clinical or diagnostic decisions.

Docs: <https://docs.genomicintelligence.ai>
