### PR TITLE
fix(skill): update Parallel Search MCP endpoint

### DIFF
--- a/.claude/skills/add-parallel/SKILL.md
+++ b/.claude/skills/add-parallel/SKILL.md
@@ -99,7 +99,7 @@ const parallelApiKey = process.env.PARALLEL_API_KEY;
 if (parallelApiKey) {
   mcpServers['parallel-search'] = {
     type: 'http',  // REQUIRED: Must specify type for HTTP MCP servers
-    url: 'https://search-mcp.parallel.ai/mcp',
+    url: 'https://search.parallel.ai/mcp',
     headers: {
       'Authorization': `Bearer ${parallelApiKey}`
     }
@@ -144,7 +144,7 @@ Then add a new section after "## What You Can Do":
 
 You have access to two Parallel AI research tools:
 
-### Quick Web Search (`mcp__parallel-search__search`)
+### Quick Web Search (`mcp__parallel-search__web_search`)
 **When to use:** Freely use for factual lookups, current events, definitions, recent information, or verifying facts.
 
 **Examples:**


### PR DESCRIPTION
## Type of Change

- [x] **Skill (dev)** - adds a meta skill in `.claude/skills/` (instructions for Claude Code)
- [ ] **Skill (runtime)** - adds/updates `container/skills/` for the chat agent
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description

The existing `add-parallel` developer skill still points Search MCP at a retired host and names the old quick-search tool. This updates those two references to the current `https://search.parallel.ai/mcp` endpoint and `web_search` tool without changing the skill's setup flow or Task MCP guidance.

Validation:

- confirmed no retired Search MCP host or tool-name reference remains in the skill
- initialized the current endpoint without credentials and verified it exposes `web_search` and `web_fetch`
- ran `git diff --check`

The updated references were tested from a fresh checkout. The full setup skill was not run because it requires account credentials and mutates the local environment, container, and service configuration.

## For Skills

- [x] I have not made any changes to source code
- [x] My skill contains instructions for Claude to follow (not pre-built code)
- [x] I tested this skill on a fresh clone

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.